### PR TITLE
Add Alabbassia TV streaming link

### DIFF
--- a/others.txt
+++ b/others.txt
@@ -17117,4 +17117,4 @@ hy-游戏-张颜齐,http://kkk.888.3116598.xyz/api.php?n=tttt&id=6XlTpQ&tk=FgM0v
 hy-游戏-赵瑾尧,http://kkk.888.3116598.xyz/api.php?n=tttt&id=YtyNfV&tk=FgM0vQMejxvG
 hy-游戏-赵磊,http://kkk.888.3116598.xyz/api.php?n=tttt&id=NtGGwA&tk=FgM0vQMejxvG
 ,http://kkk.888.3116598.xyz/api.php?n=tttt&id=&tk=FgM0vQMejxvG
-
+Alabbassia TV,https://stream.alabbassia.com/live/alabbassia/index.m3u8


### PR DESCRIPTION
Added official Alabbassia TV HLS stream.

Channel: Alabbassia TV
Country: Iraq
Quality: 1080p
Stream: https://stream.alabbassia.com/live/alabbassia/index.m3u8
Official repository: https://github.com/Alabbassia2026/Alabbassia-TV-Official